### PR TITLE
Add SuperAdmin user and billing/clients assessment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,80 @@ Services:
 
 ---
 
+## System Administration Access
+
+### SuperAdmin Credentials
+| Field    | Value                  |
+|----------|------------------------|
+| E-mail   | `admin@sistema.com`    |
+| Senha    | `SysAdmin@2024!`       |
+| Role     | `SuperAdmin`           |
+| Status   | `Active`               |
+
+The SuperAdmin account has no `company_id` restriction — it can access all tenants. It is created by **migration 049** (`docker/mysql/migrations/049_add_superadmin_user.sql`).
+
+To apply to an existing database:
+```bash
+mysql -u pm_user -p partnership_manager < docker/mysql/migrations/049_add_superadmin_user.sql
+```
+
+> **Security note:** Change this password immediately in any non-local environment via `POST /api/auth/change-password`.
+
+---
+
+## Billing & Clients — Assessment
+
+### What's implemented
+
+| Area | Status | Notes |
+|------|--------|-------|
+| `BillingClients` CRUD | ✅ Complete | Controller, service, repo, DTOs all wired up |
+| `BillingPlans` | ✅ Complete | Plan management with MaxCompanies/MaxUsers limits |
+| `BillingSubscriptions` | ✅ Complete | Activate, Suspend, Cancel lifecycle |
+| `BillingInvoices` CRUD | ✅ Complete | Create, update, soft-delete |
+| Invoice actions | ✅ Complete | MarkAsPaid, MarkAsOverdue, Cancel |
+| PDF generation | ✅ Complete | `GET /api/invoices/{id}/pdf` |
+| Monthly invoice generation | ✅ Complete | `POST /api/invoices/generate-monthly` |
+| Invoice statistics / MRR | ✅ Complete | Revenue metrics and monthly breakdown |
+| Filtered invoice list | ✅ Complete | Filter by client, status, date range, plan |
+| `BillingPayments` table | ⚠️ Partial | Table exists and FK set up; no payment handler yet |
+| Link BillingClients ↔ core clients | ⚠️ Partial | Migration 007 adds `core_client_id` FK but no service logic using it |
+
+### Known issues / gaps
+
+1. **Duplicate broken `CREATE TABLE users` in `init.sql`** — Fixed in this branch (lines 182–184 removed).
+2. **`BillingPayments` has no repository or handler** — the table and entity exist, but payment recording isn't connected to invoice status changes. `MarkAsPaid` updates `InvoiceStatus` without creating a `BillingPayments` row.
+3. **`BillingClients` ↔ `clients` are separate entities** — there are two unrelated "client" concepts:
+   - `clients` — SaaS tenant root (multi-tenancy), used in auth and company management.
+   - `BillingClients` — billing-only entity for invoicing. Migration 007 adds `core_client_id` FK but no service code syncs them.
+4. **Invoice number race condition** — `GenerateInvoiceNumberAsync` uses `COUNT(*) + 1` without a transaction/lock; concurrent inserts can produce duplicate numbers.
+5. **Overdue detection is query-only** — `GetOverdueInvoicesAsync` finds past-due invoices but there is no Hangfire job to automatically flip their status to `Overdue`.
+
+### Billing module file map
+
+```
+backend/
+  Domain/Entities/Billing/        Client.cs, Invoice.cs, Subscription.cs, Plan.cs, Payment.cs
+  Domain/Interfaces/Billing/      IBillingRepositories.cs
+  Application/Features/Billing/
+    DTOs/                         ClientDTOs.cs, InvoiceDtos.cs, SubscriptionDtos.cs
+    Commands/                     InvoiceCommands.cs
+    Queries/                      InvoiceQueries.cs
+    Handlers/                     InvoiceCommandHandlers.cs, InvoiceQueryHandlers.cs
+  Infrastructure/Repositories/Billing/
+                                  ClientRepository.cs, InvoiceRepository.cs,
+                                  SubscriptionRepository.cs, PlanRepository.cs
+  API/Controllers/Billing/
+                                  BillingClientsController.cs, InvoicesController.cs,
+                                  SubscriptionsController.cs
+
+frontend/
+  pages/billing/                  BillingDashboard.tsx, Invoices.tsx, ClientsSubscriptions.tsx
+  components/modals/              InvoiceModal.tsx, SubscriptionModal.tsx
+```
+
+---
+
 ## Code Conventions
 
 ### C# Backend

--- a/docker/mysql/init.sql
+++ b/docker/mysql/init.sql
@@ -179,10 +179,6 @@ CREATE TABLE IF NOT EXISTS BillingPayments (
 -- CORE TABLES (Continued)
 -- =====================================================
 
-CREATE TABLE IF NOT EXISTS users (
-    INDEX idx_company_deleted (is_deleted)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-
 -- Users Table
 CREATE TABLE IF NOT EXISTS users (
     id CHAR(36) PRIMARY KEY,
@@ -300,5 +296,13 @@ VALUES (
     NOW(),
     1
 );
+
+-- =====================================================
+-- NOTE: The SuperAdmin system user is inserted by
+-- migration 049_add_superadmin_user.sql (requires the
+-- clients table and client_id column on users, added
+-- by migrations 003 and 005).
+-- Credentials: admin@sistema.com / SysAdmin@2024!
+-- =====================================================
 
 SELECT 'Database initialized successfully!' AS status;

--- a/docker/mysql/migrations/049_add_superadmin_user.sql
+++ b/docker/mysql/migrations/049_add_superadmin_user.sql
@@ -1,0 +1,69 @@
+-- =====================================================
+-- Migration 049: Add SuperAdmin system user
+-- Date: 2026-03-05
+-- Description: Cria cliente e usuário SuperAdmin para
+--              administração do sistema (acesso irrestrito).
+-- Dependencies: 003_create_clients_table.sql,
+--               005_add_client_id_to_users.sql
+-- =====================================================
+-- Credentials:
+--   E-mail : admin@sistema.com
+--   Senha  : SysAdmin@2024!
+-- =====================================================
+
+USE partnership_manager;
+
+-- =====================================================
+-- STEP 1: Cliente raiz do administrador do sistema
+-- =====================================================
+INSERT IGNORE INTO clients
+    (id, name, trading_name, document, document_type, email, status, created_at, updated_at)
+VALUES (
+    '00000001-0000-4000-a000-000000000001',
+    'Administração do Sistema',
+    'Sistema Admin',
+    '00000000000191',   -- documento fictício exclusivo para conta de sistema
+    'cnpj',
+    'admin@sistema.com',
+    'Active',
+    NOW(),
+    NOW()
+);
+
+-- =====================================================
+-- STEP 2: Usuário SuperAdmin
+-- =====================================================
+-- password_hash = BCrypt cost 11 de 'SysAdmin@2024!'
+INSERT IGNORE INTO users
+    (id, client_id, company_id, email, name, password_hash, status, language,
+     failed_login_attempts, created_at, updated_at)
+VALUES (
+    '00000001-0000-4000-a000-000000000002',
+    '00000001-0000-4000-a000-000000000001',
+    NULL,
+    'admin@sistema.com',
+    'Administrador do Sistema',
+    '$2b$11$pmw/gvuc1Oj0QImkIJBoK.ICPg3PDsa7azdPKNifsti7KXjY2uN1a',
+    'Active',
+    'Portuguese',
+    0,
+    NOW(),
+    NOW()
+);
+
+-- =====================================================
+-- STEP 3: Role SuperAdmin
+-- =====================================================
+INSERT IGNORE INTO user_roles
+    (id, user_id, role, granted_at, is_active, created_at, updated_at)
+VALUES (
+    '00000001-0000-4000-a000-000000000003',
+    '00000001-0000-4000-a000-000000000002',
+    'SuperAdmin',
+    NOW(),
+    1,
+    NOW(),
+    NOW()
+);
+
+SELECT 'Migration 049 applied: SuperAdmin user created.' AS status;


### PR DESCRIPTION
- migration 049: creates SuperAdmin client + user (admin@sistema.com / SysAdmin@2024!) with BCrypt cost-11 hash and Role=SuperAdmin, company_id=NULL (full access)
- init.sql: remove broken duplicate CREATE TABLE users statement (lines 182-184)
- init.sql: add comment pointing to migration 049 for SuperAdmin seed
- CLAUDE.md: add System Administration Access section with credentials
- CLAUDE.md: add Billing & Clients assessment with implementation status, known issues (payment gap, dual-client entities, invoice number race, no overdue job) and full billing module file map

https://claude.ai/code/session_01WPft9vL6eHnkzUn4bgv14X